### PR TITLE
Available spots setting

### DIFF
--- a/client/cypress/e2e/settings.cy.ts
+++ b/client/cypress/e2e/settings.cy.ts
@@ -15,6 +15,7 @@ describe('Settings', () => {
 
     it('Should have Available Spots tab', () => {
       cy.contains('#mat-tab-group-0-label-2', 'Available Spots').click();
+      //used cypress recording lab to figure out what the tab label was
       cy.contains('Set the number of available spots').should('be.visible');
     });
 

--- a/client/cypress/e2e/settings.cy.ts
+++ b/client/cypress/e2e/settings.cy.ts
@@ -1,0 +1,49 @@
+import { SettingsPage } from 'cypress/support/settings.po';
+
+describe('Settings', () => {
+  const page = new SettingsPage();
+
+  beforeEach(() => {
+    page.navigateTo();
+  });
+
+  it('Should have the correct title', () => {
+    page.getTitle().should('have.text', 'Settings')
+  })
+
+  describe('Available Spots', () => {
+
+    it('Should have Available Spots tab', () => {
+      cy.contains('#mat-tab-group-0-label-2', 'Available Spots').click();
+      cy.contains('Set the number of available spots').should('be.visible');
+    });
+
+    it('Should allow typing in the Available Spots Form', () => {
+      cy.contains('#mat-tab-group-0-label-2', 'Available Spots').click();
+      page.getFormField('availableSpots').type('{backspace}{backspace}')
+      page.getFormField('availableSpots').type('84');
+    });
+
+    it('Should disable the save button if the form is invalid', () => {
+      cy.contains('#mat-tab-group-0-label-2', 'Available Spots').click();
+
+      page.getFormField('availableSpots').type('{backspace}{backspace}')
+      page.getSaveButton().should('be.disabled');
+      page.getFormField('availableSpots').type('84');
+      page.getSaveButton().should('be.enabled');
+    });
+
+    it('Should save Available Spots input', () => {
+      cy.contains('#mat-tab-group-0-label-2', 'Available Spots').click();
+
+      page.getFormField('availableSpots').type('{backspace}{backspace}')
+
+      page.getFormField('availableSpots').type('84');
+      cy.get('[data-test="saveButton"]').click();
+
+      cy.get('.mat-mdc-simple-snack-bar')
+        .should('be.visible')
+        .and('contain.text', 'Available spots setting saved');
+    });
+  });
+});

--- a/client/cypress/support/settings.po.ts
+++ b/client/cypress/support/settings.po.ts
@@ -1,0 +1,32 @@
+export class SettingsPage {
+
+  private readonly url = '/settings';
+  private readonly title = '.settings-title';
+  private readonly button = '[data-test=saveButton]';
+  private readonly snackBar = ''
+
+
+  navigateTo() {
+    return cy.visit(this.url);
+  }
+
+  getTitle() {
+    return cy.get(this.title);
+  }
+
+  getFormField(fieldName: string) {
+    return cy.get(`[formcontrolname="${fieldName}"]`); //removed ${this.formFieldSelector}
+  }
+
+  getSaveButton() {
+    return cy.get(this.button);
+  }
+
+  getSnackBar() {
+    // Since snackBars are often shown in response to errors,
+    // we'll add a timeout of 10 seconds to help increase the likelihood that
+    // the snackbar becomes visible before we might fail because it
+    // hasn't (yet) appeared.
+    return cy.get(this.snackBar, { timeout: 10000 });
+  }
+}

--- a/client/src/app/settings/settings.component.html
+++ b/client/src/app/settings/settings.component.html
@@ -102,6 +102,35 @@
           </div>
         </mat-tab>
 
+
+               <!-- ── Available Spots Tab ── -->
+        <mat-tab label="Available Spots">
+          <div class="tab-content">
+            <p class="tab-description">
+              Set the number of available spots for each time slot of the event.
+              This will be the maximum number of people allowed at the event for each time slot.
+            </p>
+
+              <div class="flex-col">
+
+                <form [formGroup]="availableSpotsForm" (ngSubmit)="saveAvailableSpots()">
+                  <mat-form-field>
+                    <mat-label>Available Spots</mat-label>
+                    <input matInput formControlName="availableSpots" placeholder="e.g. 5">
+                    <mat-error *ngIf="availableSpotsForm.get('availableSpots')?.hasError('required')">Required</mat-error>
+                  </mat-form-field>
+
+                  <div class="save-button">
+                    <button mat-raised-button color="primary" type="submit" [disabled]="!availableSpotsForm.valid">
+                      Save Available Spots
+                    </button>
+                  </div>
+
+                </form>
+              </div>
+          </div>
+        </mat-tab>
+
         <!-- ── Drive Order Tab ── -->
         <mat-tab label="Drive Order">
           <div class="tab-content">

--- a/client/src/app/settings/settings.component.html
+++ b/client/src/app/settings/settings.component.html
@@ -1,7 +1,7 @@
 <div class="settings-container">
   <mat-card>
     <mat-card-header>
-      <mat-card-title>Settings</mat-card-title>
+      <mat-card-title class="settings-title">Settings</mat-card-title>
     </mat-card-header>
 
     <mat-card-content>
@@ -121,7 +121,7 @@
                   </mat-form-field>
 
                   <div class="save-button">
-                    <button mat-raised-button color="primary" type="submit" [disabled]="!availableSpotsForm.valid">
+                    <button mat-raised-button color="primary" type="submit" [disabled]="!availableSpotsForm.valid" data-test="saveButton">
                       Save Available Spots
                     </button>
                   </div>

--- a/client/src/app/settings/settings.component.spec.ts
+++ b/client/src/app/settings/settings.component.spec.ts
@@ -37,6 +37,7 @@ describe('SettingsComponent – drive order', () => {
       lateAfternoon: '',
     },
     supplyOrder: [],
+    availableSpots: 5,
   };
 
   beforeEach(async () => {

--- a/client/src/app/settings/settings.component.spec.ts
+++ b/client/src/app/settings/settings.component.spec.ts
@@ -12,7 +12,7 @@ import { TermsService } from '../terms/terms.service';
 import { AppSettings } from './settings';
 import { Terms } from '../terms/terms';
 
-describe('SettingsComponent – drive order', () => {
+describe('SettingsComponent', () => {
   let component: SettingsComponent;
   let fixture: ComponentFixture<SettingsComponent>;
   let settingsServiceSpy: jasmine.SpyObj<SettingsService>;
@@ -46,6 +46,7 @@ describe('SettingsComponent – drive order', () => {
       'updateSchools',
       'updateTimeAvailability',
       'updateSupplyOrder',
+      'updateAvailableSpots'
     ]);
     termsServiceSpy = jasmine.createSpyObj('TermsService', ['getTerms']);
     snackBarSpy = jasmine.createSpyObj('MatSnackBar', ['open']);
@@ -404,5 +405,25 @@ describe('SettingsComponent – drive order', () => {
     component.saveTimeAvailability();
 
     expect(settingsServiceSpy.updateTimeAvailability).not.toHaveBeenCalled();
+  });
+
+  it('Should call updateAvailableSpots and show success snack bar', () => {
+    settingsServiceSpy.updateAvailableSpots.and.returnValue(of(undefined));
+    component.availableSpotsForm.setValue({ availableSpots: 28 });
+
+    component.saveAvailableSpots();
+
+    const availableSpots = component.availableSpotsForm.get('availableSpots').value;
+
+    expect(snackBarSpy.open).toHaveBeenCalledWith(`Available spots setting saved: ${availableSpots}`, 'OK', { duration: 2000 });
+  });
+
+  it('Should call updateAvailableSpots and show failure snack bar', () => {
+    settingsServiceSpy.updateAvailableSpots.and.returnValue(throwError(() => new Error('fail')));
+    component.availableSpotsForm.setValue({ availableSpots: 28 });
+
+    component.saveAvailableSpots();
+
+    expect(snackBarSpy.open).toHaveBeenCalledWith(`Failed to save available spots`, 'OK', { duration: 3000 });
   });
 });

--- a/client/src/app/settings/settings.component.ts
+++ b/client/src/app/settings/settings.component.ts
@@ -73,7 +73,7 @@ export class SettingsComponent implements OnInit {
   });
 
   availableSpotsForm = new FormGroup({
-    availableSpots: new FormControl<number>(null, Validators.required)
+    availableSpots: new FormControl<number>(5, [Validators.required, Validators.min(1)])
   })
 
   // Drive Order: three buckets of item terms (e.g. "notebook", "folder")
@@ -81,12 +81,14 @@ export class SettingsComponent implements OnInit {
   unstagedTerms: string[] = []; // included in the drive, appended after staged items
   notGivenTerms: string[] = []; // excluded from checklists entirely
 
+  //loads values from backend
   ngOnInit(): void {
     this.settingsService.getSettings().subscribe(settings => {
       this.schools = settings.schools ?? [];
       if (settings.timeAvailability) {
         this.timeAvailabilityForm.patchValue(settings.timeAvailability);
       }
+      this.availableSpotsForm.patchValue({ availableSpots: settings.availableSpots});
     });
 
     this.loadDriveOrder();
@@ -216,7 +218,11 @@ export class SettingsComponent implements OnInit {
       this.settingsService.updateAvailableSpots(
         this.availableSpotsForm.value as number
       ).subscribe({
-        next: () => this.snackBar.open('Available spots saved', 'OK', { duration: 2000 }),
+        next: () => {
+          const availableSpots = this.availableSpotsForm.value.availableSpots;
+          console.log('Updated spots:', availableSpots);
+          this.snackBar.open(`Available spots setting saved: ${availableSpots}`, 'OK', { duration: 2000 });
+        },
         error: () => this.snackBar.open('Failed to save available spots', 'OK', { duration: 3000 })
       });
     }

--- a/client/src/app/settings/settings.component.ts
+++ b/client/src/app/settings/settings.component.ts
@@ -72,6 +72,10 @@ export class SettingsComponent implements OnInit {
     lateAfternoon: new FormControl('', Validators.required),
   });
 
+  availableSpotsForm = new FormGroup({
+    availableSpots: new FormControl<number>(null, Validators.required)
+  })
+
   // Drive Order: three buckets of item terms (e.g. "notebook", "folder")
   stagedTerms: string[] = [];    // included in the drive, checklist order matches this list
   unstagedTerms: string[] = []; // included in the drive, appended after staged items
@@ -203,6 +207,17 @@ export class SettingsComponent implements OnInit {
       ).subscribe({
         next: () => this.snackBar.open('Time availability saved', 'OK', { duration: 2000 }),
         error: () => this.snackBar.open('Failed to save time availability', 'OK', { duration: 3000 })
+      });
+    }
+  }
+
+  saveAvailableSpots(): void {
+    if (this.availableSpotsForm.valid) {
+      this.settingsService.updateAvailableSpots(
+        this.availableSpotsForm.value as number
+      ).subscribe({
+        next: () => this.snackBar.open('Available spots saved', 'OK', { duration: 2000 }),
+        error: () => this.snackBar.open('Failed to save available spots', 'OK', { duration: 3000 })
       });
     }
   }

--- a/client/src/app/settings/settings.service.spec.ts
+++ b/client/src/app/settings/settings.service.spec.ts
@@ -26,6 +26,7 @@ describe('SettingsService', () => {
       { itemTerm: 'folder', status: 'unstaged' },
       { itemTerm: 'pencil', status: 'notGiven' },
     ],
+    availableSpots: 5,
   };
 
   beforeEach(() => {

--- a/client/src/app/settings/settings.service.spec.ts
+++ b/client/src/app/settings/settings.service.spec.ts
@@ -132,4 +132,17 @@ describe('SettingsService', () => {
       req.flush(null);
     });
   });
+
+  describe('updateAvailableSpots()', () => {
+    it('sends PATCH to /api/settings/availableSpots', () => {
+      const updatedValue = 28;
+
+      service.updateAvailableSpots(updatedValue).subscribe();
+
+      const req = httpTestingController.expectOne(`${settingsUrl}/availableSpots`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual(updatedValue);
+      req.flush(null);
+    });
+  });
 });

--- a/client/src/app/settings/settings.service.ts
+++ b/client/src/app/settings/settings.service.ts
@@ -36,4 +36,9 @@ export class SettingsService {
   updateSupplyOrder(order: SupplyItemOrder[]): Observable<void> {
     return this.httpClient.patch<void>(`${this.settingsUrl}/supplyOrder`, { supplyOrder: order });
   }
+
+  // Replaces the availableSpots setting with a new number
+  updateAvailableSpots(availableSpots: number): Observable<void> {
+    return this.httpClient.patch<void>(`${this.settingsUrl}/availableSpots`, { availableSpots } )
+  }
 }

--- a/client/src/app/settings/settings.service.ts
+++ b/client/src/app/settings/settings.service.ts
@@ -39,6 +39,6 @@ export class SettingsService {
 
   // Replaces the availableSpots setting with a new number
   updateAvailableSpots(availableSpots: number): Observable<void> {
-    return this.httpClient.patch<void>(`${this.settingsUrl}/availableSpots`, { availableSpots } )
+    return this.httpClient.patch<void>(`${this.settingsUrl}/availableSpots`, availableSpots);
   }
 }

--- a/client/src/app/settings/settings.ts
+++ b/client/src/app/settings/settings.ts
@@ -15,13 +15,14 @@ export interface TimeAvailabilityLabels {
   lateAfternoon: string;
 }
 
-export type availableSpots= number;
+// export type availableSpots= number;
 
 export interface AppSettings {
   _id?: string;
   schools: SchoolInfo[];
   timeAvailability: TimeAvailabilityLabels;
   supplyOrder: SupplyItemOrder[];
+  availableSpots: number;
 }
 
 // Service for managing application settings, including schools, time availability labels, and supply order.

--- a/client/src/app/settings/settings.ts
+++ b/client/src/app/settings/settings.ts
@@ -15,6 +15,8 @@ export interface TimeAvailabilityLabels {
   lateAfternoon: string;
 }
 
+export type availableSpots= number;
+
 export interface AppSettings {
   _id?: string;
   schools: SchoolInfo[];

--- a/server/src/main/java/umm3601/settings/Settings.java
+++ b/server/src/main/java/umm3601/settings/Settings.java
@@ -16,7 +16,7 @@ import org.mongojack.Id;
  *
  * Only one document ever exists, identified by _id = "app-settings".
  */
-@SuppressWarnings({"VisibilityModifier"})
+@SuppressWarnings({"VisibilityModifier", "MagicNumber"})
 public class Settings {
 
   @Id
@@ -49,6 +49,12 @@ public class Settings {
     public String earlyAfternoon;
     public String lateAfternoon;
   }
+
+    /**
+   * Spots available per time slot at the drive
+   * Used to schedule families between the different time slots based on their preferences
+   */
+  public int availableSpots = 5;
 
   /**
    * Records how a single supply list entry should be treated on drive day.

--- a/server/src/main/java/umm3601/settings/SettingsController.java
+++ b/server/src/main/java/umm3601/settings/SettingsController.java
@@ -34,6 +34,7 @@ import umm3601.Controller;
  *  - GET  /api/settings                     → returns the full settings document
  *  - PATCH /api/settings/schools            → replaces the schools list
  *  - PATCH /api/settings/timeAvailability   → replaces the time availability labels
+ *  - PATCH /api/settings/availableSpots     → replaces the availableSpots integer
  *
  * Patching by section prevents one tab from overwriting another's changes.
  * All patch operations use upsert so the document is created on first write.
@@ -47,6 +48,9 @@ public class SettingsController implements Controller {
   private static final String API_SETTINGS_SCHOOLS = "/api/settings/schools";
   private static final String API_SETTINGS_TIME = "/api/settings/timeAvailability";
   private static final String API_SETTINGS_SUPPLY_ORDER = "/api/settings/supplyOrder";
+  private static final String API_SETTINGS_AVAILABLE_SPOTS = "/api/settings/availableSpots";
+
+  private static final int DEFAULT_AVAILABLE_SPOTS = 5;
 
   private final JacksonMongoCollection<Settings> settingsCollection;
 
@@ -69,6 +73,7 @@ public class SettingsController implements Controller {
       settings._id = SETTINGS_ID;
       settings.schools = new ArrayList<>();
       settings.timeAvailability = new Settings.TimeAvailabilityLabels();
+      settings.availableSpots = DEFAULT_AVAILABLE_SPOTS;
       settings.supplyOrder = new ArrayList<>();
     } else if (settings.supplyOrder == null) {
       settings.supplyOrder = new ArrayList<>();
@@ -150,11 +155,23 @@ public class SettingsController implements Controller {
     ctx.status(HttpStatus.OK);
   }
 
+  public void updateSpotAvailability(Context ctx) {
+    Settings body = ctx.bodyAsClass(Settings.class);
+
+    settingsCollection.updateOne(
+        eq("_id", SETTINGS_ID),
+        new Document("$set", new Document("availableSpots", body.availableSpots)),
+        new UpdateOptions().upsert(true));
+
+    ctx.status(HttpStatus.OK);
+  }
+
   @Override
   public void addRoutes(Javalin server) {
     server.get(API_SETTINGS, this::getSettings);
     server.patch(API_SETTINGS_SCHOOLS, this::updateSchools);
     server.patch(API_SETTINGS_TIME, this::updateTimeAvailability);
+    server.patch(API_SETTINGS_AVAILABLE_SPOTS, this::updateSpotAvailability);
     server.patch(API_SETTINGS_SUPPLY_ORDER, this::updateSupplyOrder);
   }
 }

--- a/server/src/test/java/umm3601/settings/SettingsControllerSpec.java
+++ b/server/src/test/java/umm3601/settings/SettingsControllerSpec.java
@@ -403,4 +403,18 @@ class SettingsControllerSpec {
     assertNotNull(settingsCaptor.getValue().supplyOrder);
     assertEquals(0, settingsCaptor.getValue().supplyOrder.size());
   }
+
+  @Test
+  void updateSpotAvailabilityTest() {
+    Settings body = new Settings();
+    // body.availableSpots = 5;
+
+    when(ctx.bodyAsClass(Settings.class)).thenReturn(body);
+
+    settingsController.updateSpotAvailability(ctx);
+
+    assertEquals(body.availableSpots, 5);
+
+    verify(ctx).status(HttpStatus.OK);
+  }
 }


### PR DESCRIPTION
This adds an adjustable available spots setting so the user can set the maximum amount of people that they want to allow during each time slot of the event. 

This will help with properly scheduling families.

Close #41