### PR TITLE
Fixes for PDF Generation

### DIFF
--- a/client/src/app/family/family.service.spec.ts
+++ b/client/src/app/family/family.service.spec.ts
@@ -728,6 +728,7 @@ describe('FamilyService', () => {
 
     it('should call getDashboardStats when generating PDF', fakeAsync(() => {
       const getDashboardStatsSpy = spyOn(familyService, 'getDashboardStats').and.returnValue(of(mockDashboardStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       spyOn(familyService['snackBar'], 'open');
 
       familyService.generatePDF();
@@ -738,6 +739,7 @@ describe('FamilyService', () => {
 
     it('should show snackbar notification when PDF generation starts', fakeAsync(() => {
       spyOn(familyService, 'getDashboardStats').and.returnValue(of(mockDashboardStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       const snackBarSpy = spyOn(familyService['snackBar'], 'open');
 
       familyService.generatePDF();
@@ -752,6 +754,7 @@ describe('FamilyService', () => {
 
     it('should include all families in PDF when generating', fakeAsync(() => {
       spyOn(familyService, 'getDashboardStats').and.returnValue(of(mockDashboardStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       spyOn(familyService['snackBar'], 'open');
 
       familyService.generatePDF();
@@ -766,6 +769,7 @@ describe('FamilyService', () => {
 
     it('should process all dashboard statistics categories', fakeAsync(() => {
       const getDashboardStatsSpy = spyOn(familyService, 'getDashboardStats').and.returnValue(of(mockDashboardStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       spyOn(familyService['snackBar'], 'open');
 
       familyService.generatePDF();
@@ -783,6 +787,7 @@ describe('FamilyService', () => {
 
     it('should load families before generating PDF', fakeAsync(() => {
       spyOn(familyService, 'getDashboardStats').and.returnValue(of(mockDashboardStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       spyOn(familyService['snackBar'], 'open');
 
       expect(familyService.family().length).toBeGreaterThan(0);
@@ -801,6 +806,7 @@ describe('FamilyService', () => {
       };
 
       spyOn(familyService, 'getDashboardStats').and.returnValue(of(emptySchoolsStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       const snackBarSpy = spyOn(familyService['snackBar'], 'open');
 
       familyService.generatePDF();
@@ -820,6 +826,7 @@ describe('FamilyService', () => {
       };
 
       spyOn(familyService, 'getDashboardStats').and.returnValue(of(emptyGradesStats));
+      spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
       const snackBarSpy = spyOn(familyService['snackBar'], 'open');
 
       familyService.generatePDF();
@@ -834,6 +841,7 @@ describe('FamilyService', () => {
         spyOn(familyService, 'getDashboardStats').and.returnValue(
           new Observable(observer => observer.error(error))
         );
+        spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
         spyOn(console, 'error');
         const snackBarSpy = spyOn(familyService['snackBar'], 'open');
 
@@ -850,6 +858,7 @@ describe('FamilyService', () => {
 
       it('should handle errors gracefully during PDF generation', fakeAsync(() => {
         spyOn(familyService, 'getDashboardStats').and.returnValue(of(mockDashboardStats));
+        spyOn(familyService, 'getFamilies').and.returnValue(of(testFamilies));
         spyOn(console, 'error');
         const snackBarSpy = spyOn(familyService['snackBar'], 'open');
 

--- a/client/src/app/family/family.service.ts
+++ b/client/src/app/family/family.service.ts
@@ -344,7 +344,6 @@ export class FamilyService {
     const accomBoxX = detailsBoxWidth + 5; // Offset from details box
     const accomBoxWidth = accomBoxX + boxWidth; // Width of accommodations box, next box is offset from this
     const accomMaxWidth = boxWidth - 10; // Max width for text in box
-    const accomBoxHeight = 10; // Minimum height, will expand if text is long
 
     // Accommodations label
     this.addText(doc, "Accommodations:", accomBoxX + labelOffsetX, boxY + labelOffsetY, 12, "bold", "normal");
@@ -355,7 +354,8 @@ export class FamilyService {
     });
 
     // Accomodations box
-    const accomDynamicHeight = Math.max(accomBoxHeight, (5 + lineSpacing) + (doc.splitTextToSize(family.accommodations || 'None', accomMaxWidth).length * (lineHeight + lineSpacing)));
+    // Dynamic height based on number of lines + some padding (defaults to same size as contact details box if no adjustments are needed)
+    const accomDynamicHeight = Math.max(boxHeight, (doc.splitTextToSize(family.accommodations || 'None', accomMaxWidth).length * (lineHeight*1.1 + lineSpacing*1.1)));
     doc.roundedRect(accomBoxX, boxY, boxWidth, accomDynamicHeight, 3, 3);
 
     // Time Slot and Availability \\

--- a/client/src/app/family/family.service.ts
+++ b/client/src/app/family/family.service.ts
@@ -227,7 +227,7 @@ export class FamilyService {
       .sort(([schoolA], [schoolB]) => schoolA.localeCompare(schoolB))
       .map(([school, count]) => {
         const cleaned = school
-          .replace('School', '') // remove the word 'School'
+          .replace(/School$/i, '') // remove variations of "School" from the end of the name
           .trim();
         return `  • ${cleaned}: ${count}`;
       })

--- a/client/src/app/family/family.service.ts
+++ b/client/src/app/family/family.service.ts
@@ -8,7 +8,7 @@ import jsPDF, { jsPDF as jsPDFClass } from "jspdf";
 import autoTable from "jspdf-autotable";
 
 // RxJS Imports
-import { Observable } from 'rxjs';
+import { forkJoin, Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 
 // Other Imports
@@ -449,10 +449,14 @@ export class FamilyService {
     doc.line(10, 30, 200, 30);
     doc.setLineWidth(thinLineWidth);
 
-    // Dashboard stats
-    this.getDashboardStats().subscribe({
-      next: (stats) => {
+    forkJoin({ // Ensure dashboard and family data is up-to-date
+      stats: this.getDashboardStats(),
+      families: this.getFamilies()
+    }).subscribe({
+      next: ({ stats, families }) => {
         try {
+          this.family.set(families);
+
           // Box vars
           const boxX = 10; // Starting x, following boxes offset from this
           const boxY = 40;
@@ -509,12 +513,12 @@ export class FamilyService {
           const maxY = doc.internal.pageSize.getHeight() - 15;
           let lastY = 15;
 
-          for (let i = 0; i < this.family().length; i++) {
+          for (let i = 0; i < families.length; i++) {
             if (i === 0) { // First family, add page after dashboard stats
               doc.addPage();
             }
 
-            const currentFamily = this.family()[i];
+            const currentFamily = families[i];
             let currentOffset = 15; // Determine offset for current family
 
             if (i > 0) {  // Not first family

--- a/client/src/app/family/family.service.ts
+++ b/client/src/app/family/family.service.ts
@@ -225,7 +225,12 @@ export class FamilyService {
   private formatSchoolsList(schoolsData: Record<string, number>): string {
     return Object.entries(schoolsData)
       .sort(([schoolA], [schoolB]) => schoolA.localeCompare(schoolB))
-      .map(([school, count]) => `  • ${school}: ${count}`)
+      .map(([school, count]) => {
+        const cleaned = school
+          .replace('School', '') // remove the word 'School'
+          .trim();
+        return `  • ${cleaned}: ${count}`;
+      })
       .join('\n');
   }
 
@@ -484,7 +489,7 @@ export class FamilyService {
 
           // School Stats List
           this.addText(doc, "Students Per School", schoolBoxX + labelOffsetX, boxY + labelOffsetY, 14, "bold", "normal");
-          this.addText(doc, studentsPerSchool, schoolBoxX + labelOffsetX, boxY + labelOffsetY + 5, 10, "normal", "normal");
+          this.addText(doc, studentsPerSchool, schoolBoxX + labelOffsetX - 2, boxY + labelOffsetY + 5, 10, "normal", "normal");
 
           // Grade Stats box
           const gradeLines = Math.max(gradesLeft.split('\n').length, gradesRight.split('\n').length);

--- a/client/src/app/stock-report/report-generator/report-generator.component.ts
+++ b/client/src/app/stock-report/report-generator/report-generator.component.ts
@@ -52,6 +52,8 @@ export class ReportGeneratorComponent {
   private snackBar = inject(MatSnackBar);
   private formatDateTimeService = inject(FormatDateTimeService);
   private authService = inject(AuthService);
+  private readonly pageBreakThreshold = 0.75; // Percentage of page height to trigger page break
+  private readonly tablePageTopY = 15;
 
   get canViewReports(): boolean {
     return this.authService.hasPermission('view_reports');
@@ -93,6 +95,31 @@ export class ReportGeneratorComponent {
   });
 
   /**
+   * Custom helper function to add text with specified styling
+   */
+  private addText(doc: jsPDF, text: string, x: number, y: number, size: number, weight: string, font: string): void {
+    doc.setFont(undefined, weight);
+    doc.setFontSize(size);
+    doc.text(text, x, y);
+    doc.setFont(undefined, font);
+  }
+
+  /**
+   * Moves a new table to a new page if there isn't enough space left on the current page
+   * @returns Y coordinate to start new table
+   */
+  private checkForPageBreak(doc: jsPDFWithAutoTable, tableStartY: number): number {
+    const pageHeight = doc.internal.pageSize.getHeight();
+
+    if (tableStartY >= pageHeight * this.pageBreakThreshold) {
+      doc.addPage();
+      return this.tablePageTopY;
+    }
+
+    return tableStartY;
+  }
+
+  /**
    * Generates a PDF report of the inventory, grouped by Stock State. Each group has its own table with item description, quantity, max quantity, and min quantity.
    * The PDF is saved with the name "StockReport_MM-DD-YYYY.pdf", using formatDateTime to get the formatted date. The PDF also includes a title and description with the date.
    * @param savePdf boolean indicating whether to save PDF to server (true) or download to client machine (false)
@@ -109,18 +136,19 @@ export class ReportGeneratorComponent {
 
     const doc = new jsPDF() as jsPDFWithAutoTable;
     // Title
-    doc.setFontSize(16);
-    doc.text("Stock Report", 10, 10);
+    this.addText(doc, "Stock Report", 10, 10, 16, 'bold', 'normal');
     // Description
-    doc.setFontSize(12);
-    doc.text("This is a Stock Report of the inventory on ${formattedDate}".replace("${formattedDate}", this.formatDateTimeService.formatDateTime(this.dateTime)[0]), 10, 20);
+    this.addText(doc, `Report generated on ${this.formatDateTimeService.formatDateTime(this.dateTime)[0]}`, 10, 25, 12, 'normal', 'normal');
+    doc.line(10, 28, 200, 28); // Horizontal line under title and description
 
     // Table Constants
     const headers = [["Item Description", "Quantity", "Max Quantity", "Min Quantity", "Notes"]];
-    const tableSpace = 10; // 10mm of space
-    const titleSpace = 1; // 5mm of space
+    const tableSpace = 20; // 20mm of space
+    const titleSpace = 3; // 3mm of space
     const itemSpace = 80; // Item column width
     const quantitySpace = 20; // Quantity/Max/Min column width
+    const startY = 35; // Starting Y position for the first table
+    const tableX = 15; // X position for all tables
     const columnStyling = {
       0: { // Item
         cellWidth: itemSpace
@@ -137,25 +165,21 @@ export class ReportGeneratorComponent {
     };
 
     // Stocked Table
-    const startY1 = 30; // Starting Y position for the first table
-
-    doc.setFontSize(12);
-    doc.text("Stocked Items", 15, 30);
+    this.addText(doc, "Stocked Items", tableX, startY, 12, 'normal', 'normal');
     autoTable(doc, {
       head: headers,
       body: this.stockedItems(),
-      startY: startY1+titleSpace,
+      startY: startY+titleSpace,
       theme: 'striped',
       columnStyles: columnStyling
     });
 
     // Calculate the startY for the second table
     // doc.lastAutoTable.finalY holds the Y-coordinate of the last drawn point of the table
-    const startY2 = (doc.lastAutoTable?.finalY) + tableSpace;
+    const startY2 = this.checkForPageBreak(doc, (doc.lastAutoTable?.finalY ?? startY) + tableSpace);
 
     // Out of Stock Table
-    doc.setFontSize(12);
-    doc.text("Out of Stock Items", 15, startY2);
+    this.addText(doc, "Out of Stock Items", tableX, startY2, 12, 'normal', 'normal');
     autoTable(doc, {
       head: headers,
       body: this.outOfStockItems(),
@@ -164,11 +188,10 @@ export class ReportGeneratorComponent {
       columnStyles: columnStyling
     });
 
-    const startY3 = (doc.lastAutoTable?.finalY) + tableSpace;
+    const startY3 = this.checkForPageBreak(doc, (doc.lastAutoTable?.finalY ?? startY2) + tableSpace);
 
     // Overstocked Table
-    doc.setFontSize(12);
-    doc.text("Overstocked Items", 15, startY3);
+    this.addText(doc, "Overstocked Items", tableX, startY3, 12, 'normal', 'normal');
     autoTable(doc, {
       head: headers,
       body: this.overstockedItems(),
@@ -177,11 +200,10 @@ export class ReportGeneratorComponent {
       columnStyles: columnStyling
     });
 
-    const startY4 = (doc.lastAutoTable?.finalY) + tableSpace;
+    const startY4 = this.checkForPageBreak(doc, (doc.lastAutoTable?.finalY ?? startY3) + tableSpace);
 
     // Understocked Table
-    doc.setFontSize(12);
-    doc.text("Understocked Items", 15, startY4);
+    this.addText(doc, "Understocked Items", tableX, startY4, 12, 'normal', 'normal');
     autoTable(doc, {
       head: headers,
       body: this.understockedItems(),

--- a/server/src/main/java/umm3601/StockReport/StockReportController.java
+++ b/server/src/main/java/umm3601/StockReport/StockReportController.java
@@ -405,7 +405,7 @@ public class StockReportController {
   public void generateStockReport(Context ctx, boolean saveToDatabase) {
     String timestamp = java.time.LocalDateTime.now()
     .format(java.time.format.DateTimeFormatter
-      .ofPattern("yyyy-MM-dd_HH:mm"));
+      .ofPattern("yyyy-MM-dd_HH-mm"));
 
     try {
       byte[] workbookBytes = createXLSXFile();


### PR DESCRIPTION
Fixes to Family and Stock Report PDF generation

Stock Report Changes:
- Fixed XLSX file names being improper when saved to the database
- Fixed PDF spacing issues
- Updated formatting slightly
- Refactored text additions to use addText

Family Changes:
- Fixed boxes not being sized properly
- Fixed school stat text not fitting in its box
- Made it remove variations of "School" from the end of each school's name
- Fixed it not using most up-to-date dashboard and family information
- Refactored how the loop processes each individual family