### PR TITLE
Disable Visual Display of Options Button

### DIFF
--- a/client/src/app/family/family-list.component.html
+++ b/client/src/app/family/family-list.component.html
@@ -175,32 +175,35 @@
 </div>
 
 <!-- Options Menu -->
-<div class="fab-container">
-  <button mat-fab class="export-toggle-fab" matTooltip="Options" matTooltipPosition="left"
-    (click)="toggleOptionsMenu()" [ngClass]="{'expanded': showOptionsMenu()}" data-cy="options-menu-toggle">
-    <mat-icon class="md-24" aria-label="Options">more_vert</mat-icon>
-  </button>
-  <!-- Add Family Button -->
-  @if (showOptionsMenu()) {
-    @if (canAddFamily) {
-    <button mat-fab class="add-family-fab" matTooltip="Add Family" matTooltipPosition="left" routerLink="/family/new"
-      data-cy="add-family-button">
-      <mat-icon class="md-24" aria-label="Add Family">add</mat-icon>
+@if (canUseFamilyOptionsMenu) {
+  <div class="fab-container">
+    <button mat-fab class="export-toggle-fab" matTooltip="Options" matTooltipPosition="left"
+      (click)="toggleOptionsMenu()" [ngClass]="{'expanded': showOptionsMenu()}" data-cy="options-menu-toggle">
+      <mat-icon class="md-24" aria-label="Options">more_vert</mat-icon>
     </button>
-    }
+    <!-- Add Family Button -->
+    @if (showOptionsMenu()) {
+      @if (canAddFamily) {
+      <button mat-fab class="add-family-fab" matTooltip="Add Family" matTooltipPosition="left" routerLink="/family/new"
+        data-cy="add-family-button">
+        <mat-icon class="md-24" aria-label="Add Family">add</mat-icon>
+      </button>
+      }
 
-    <!-- Export CSV Button -->
-    @if (canExportFamilies) {
-    <button mat-fab class="export-fab" matTooltip="Export CSV" matTooltipPosition="left" (click)="downloadCSV()"
-      data-cy="export-csv-button">
-      <mat-icon class="md-24" aria-label="Export CSV">table_chart</mat-icon>
-    </button>
+      <!-- Export CSV Button -->
+      @if (canExportFamilies) {
+      <button mat-fab class="export-fab" matTooltip="Export CSV" matTooltipPosition="left" (click)="downloadCSV()"
+        data-cy="export-csv-button">
+        <mat-icon class="md-24" aria-label="Export CSV">table_chart</mat-icon>
+      </button>
 
-    <!-- Export PDF Button -->
-    <button mat-fab class="export-fab" matTooltip="Export PDF" matTooltipPosition="left" (click)="downloadPDF()"
-      data-cy="export-pdf-button">
-      <mat-icon class="md-24" aria-label="Export PDF">picture_as_pdf</mat-icon>
-    </button>
+      <!-- Export PDF Button -->
+      <button mat-fab class="export-fab" matTooltip="Export PDF" matTooltipPosition="left" (click)="downloadPDF()"
+        data-cy="export-pdf-button">
+        <mat-icon class="md-24" aria-label="Export PDF">picture_as_pdf</mat-icon>
+      </button>
+      }
     }
+    </div>
   }
-</div>
+

--- a/client/src/app/family/family-list.component.spec.ts
+++ b/client/src/app/family/family-list.component.spec.ts
@@ -25,7 +25,7 @@ describe('Family list', () => {
   let familyList: FamilyListComponent;
   let fixture: ComponentFixture<FamilyListComponent>;
   let familyService: FamilyService;
-  let authService: jasmine.SpyObj<AuthService>
+  let authService: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
     authService = jasmine.createSpyObj<AuthService>('AuthService', ['hasPermission'])

--- a/client/src/app/family/family-list.component.spec.ts
+++ b/client/src/app/family/family-list.component.spec.ts
@@ -18,18 +18,28 @@ import { FamilyListComponent } from './family-list.component';
 import { FamilyService } from './family.service';
 import { DashboardStats } from '../family/family';
 
+// Auth Imports
+import { AuthService } from '../auth/auth-service';
+
 describe('Family list', () => {
   let familyList: FamilyListComponent;
   let fixture: ComponentFixture<FamilyListComponent>;
   let familyService: FamilyService;
+  let authService: jasmine.SpyObj<AuthService>
 
   beforeEach(() => {
+    authService = jasmine.createSpyObj<AuthService>('AuthService', ['hasPermission'])
+
+    authService.hasPermission.and.callFake(permission =>
+      ['add_family', 'export_families_csv', "edit_family", "request_familiy_delete",].includes(permission)
+    )
     TestBed.configureTestingModule({
       imports: [FamilyListComponent],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
         { provide: FamilyService, useClass: MockFamilyService },
+        { provide: AuthService, useValue: authService },
         provideRouter([])
       ],
     });

--- a/client/src/app/family/family-list.component.ts
+++ b/client/src/app/family/family-list.component.ts
@@ -98,6 +98,10 @@ export class FamilyListComponent {
     return this.authService.hasPermission('request_family_delete');
   }
 
+  get canUseFamilyOptionsMenu() : boolean {
+    return this.canAddFamily || this.canExportFamilies;
+  }
+
   /**
    * The component uses several signals to manage state related to family data, filtering options,
    * pagination, and error messages.
@@ -252,10 +256,17 @@ export class FamilyListComponent {
   }
 
   toggleOptionsMenu() {
+
+    if(!this.canUseFamilyOptionsMenu) {
+      return
+    }
     this.showOptionsMenu.update(value => !value);
   }
 
   downloadCSV() {
+    if (!this.canUseFamilyOptionsMenu) {
+      return
+    }
     this.familyService.exportFamilies().subscribe(csvData => {
       const blob = new Blob([csvData], { type: 'text/csv' });
       const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
Change the visual display of the options button that contain exporting and adding families.

The Volunteer role already did not have access to the button but this will remove the display of it as well.

Closes #101 