### PR TITLE
Update Terms Controller To Work With Current Data

### DIFF
--- a/client/src/app/supplylist/add-supplylist/add-supplylist.component.spec.ts
+++ b/client/src/app/supplylist/add-supplylist/add-supplylist.component.spec.ts
@@ -523,6 +523,18 @@ describe('AddSupplyListComponent#parseDescription()', () => {
     expect(color).toContain('|');
   });
 
+  it('should not infer container words as size when not present in terms', () => {
+    component.parseDescription('2 boxes of 24 count crayons');
+    expect(component.addSupplyListForm.get('size')?.value || '').toBe('');
+    expect(component.addSupplyListForm.get('quantity')?.value).toBe('2');
+    expect(component.addSupplyListForm.get('packageSize')?.value).toBe('24');
+  });
+
+  it('should not infer free-form size adjectives when they are not present in terms', () => {
+    component.parseDescription('large crayons');
+    expect(component.addSupplyListForm.get('size')?.value || '').toBe('');
+  });
+
   it('should parse a parenthetical note into the notes field', () => {
     component.parseDescription('crayons (for art class)');
     expect(component.addSupplyListForm.get('notes')?.value).toBe('for art class');

--- a/client/src/app/supplylist/add-supplylist/add-supplylist.component.spec.ts
+++ b/client/src/app/supplylist/add-supplylist/add-supplylist.component.spec.ts
@@ -482,6 +482,16 @@ describe('AddSupplyListComponent#parseDescription()', () => {
     expect(component.addSupplyListForm.get('packageSize')?.value).toBe('12');
   });
 
+  it('should parse packageSize from a "container of N" pattern', () => {
+    component.parseDescription('container of 24 pencils');
+    expect(component.addSupplyListForm.get('packageSize')?.value).toBe('24');
+  });
+
+  it('should parse packageSize from a "bag of N" pattern', () => {
+    component.parseDescription('bag of 30 erasers');
+    expect(component.addSupplyListForm.get('packageSize')?.value).toBe('30');
+  });
+
   it('should match an item by exact term', () => {
     component.parseDescription('notebook');
     expect(component.addSupplyListForm.get('item')?.value).toBe('notebook');

--- a/client/src/app/supplylist/add-supplylist/add-supplylist.component.ts
+++ b/client/src/app/supplylist/add-supplylist/add-supplylist.component.ts
@@ -232,10 +232,10 @@ export class AddSupplyListComponent implements OnInit {
       }
     }
 
-    // Package size: "24 count", "24ct", "pack of 24", or "box of 24".
-    // "24 count", "24ct", "24-count", "pack of 24", "box of 24"
+    // Package size: "24 count", "24ct", "pack/container/bag of 24", etc.
+    // "24 count", "24ct", "24-count", "pack of 24", "container of 24", "bag of 24"
     const packageSizeMatch = lower.match(/(\d+)\s*[-]?\s*(?:count|ct|pk|pack)\b/)
-      || lower.match(/(?:pack|box|set)\s+of\s+(\d+)/);
+      || lower.match(/(?:pack|box|set|container|bag)\s+of\s+(\d+)/);
     if (packageSizeMatch) {
       patch['packageSize'] = packageSizeMatch[1];
     }

--- a/client/src/app/supplylist/add-supplylist/add-supplylist.component.ts
+++ b/client/src/app/supplylist/add-supplylist/add-supplylist.component.ts
@@ -248,13 +248,11 @@ export class AddSupplyListComponent implements OnInit {
     }
 
     // Item: longest matching term wins to avoid "pen" matching "pencil".
-    // Longest matching term wins (avoids "pen" matching "pencil").
-    // If no item is found directly, use the brand-to-item hint map as a fallback.
+    // If no item is found directly, use brand hints only when they map to an existing term.
     let matchedItem = this.bestTermMatch(lower, this.terms.item);
     if (!matchedItem && matchedBrand) {
       const hints = this.brandItemHints[matchedBrand.toLowerCase()] ?? [];
-      matchedItem = this.bestTermMatch(hints.join(' '), this.terms.item)
-        ?? (hints.length ? hints[0] : null);
+      matchedItem = this.bestTermMatch(hints.join(' '), this.terms.item);
     }
     if (matchedItem) {
       patch['item'] = matchedItem;
@@ -267,26 +265,10 @@ export class AddSupplyListComponent implements OnInit {
       patch['color'] = matchedColors.join(sep);
     }
 
-    // Size: keep explicit size terms before inferring a container type.
-    // Size is entered as a simple text field in the form and converted to
-    // AttributeOptions during submit.
+    // Size: only use explicit size terms that already exist in the term list.
     const sizeTermMatches = this.allTermMatches(lower, this.terms.size);
-    const fallbackSize = ['large', 'medium', 'small', 'xl', 'xxl', 'xs'].find(s => lower.includes(s)) ?? null;
     if (sizeTermMatches.length) {
       patch['size'] = sizeTermMatches.join(sep);
-    } else if (fallbackSize) {
-      patch['size'] = fallbackSize;
-    }
-
-    // Default container size for descriptions like "2 boxes of 24 crayons".
-    // If quantity > 1 and no size was detected from the new DB terms,
-    // infer a container type. If a count exists, include it.
-    if (!patch['size'] && patch['quantity']) {
-      const qty = Number(patch['quantity']);
-      if (qty > 1) {
-        const packageSize = patch['packageSize'] ? ` of ${patch['packageSize']}` : '';
-        patch['size'] = `Box${packageSize}`;   // e.g., "Box of 24", "Box"
-      }
     }
 
     // Type.

--- a/database/seed/supplylist.json
+++ b/database/seed/supplylist.json
@@ -39,7 +39,7 @@
     "grade": "PreK",
     "teacher": "",
     "item": [
-      "rug"
+      "Rug"
     ],
     "brand": {
       "allOf": "",
@@ -536,7 +536,7 @@
     "grade": "Kindergarten",
     "teacher": "",
     "item": [
-      "rug"
+      "Rug"
     ],
     "brand": {
       "allOf": "",
@@ -3708,11 +3708,11 @@
       "anyOf": []
     },
     "size": {
-      "allOf": "",
+      "allOf": "#2",
       "anyOf": []
     },
     "type": {
-      "allOf": "#2",
+      "allOf": "",
       "anyOf": []
     },
     "material": {
@@ -4728,11 +4728,11 @@
       "anyOf": []
     },
     "size": {
-      "allOf": "",
+      "allOf": "#2",
       "anyOf": []
     },
     "type": {
-      "allOf": "#2",
+      "allOf": "",
       "anyOf": []
     },
     "material": {
@@ -9261,7 +9261,7 @@
     "grade": "High School",
     "teacher": "Mr. Hoffmann",
     "item": [
-      "mechanical Pencil",
+      "Mechanical Pencil",
       "Pencil"
     ],
     "brand": {
@@ -10856,7 +10856,7 @@
     "grade": "Kindergarten",
     "teacher": "",
     "item": [
-      "rug"
+      "Rug"
     ],
     "brand": {
       "allOf": "",

--- a/server/src/main/java/umm3601/terms/TermsController.java
+++ b/server/src/main/java/umm3601/terms/TermsController.java
@@ -84,8 +84,39 @@ public class TermsController {
       distinctStrings(inventoryCollection, "material")
     );
 
+    terms.type = removeOverlappingSizeMarkers(terms.type, terms.size);
+
     ctx.json(terms);
     ctx.status(HttpStatus.OK);
+  }
+
+  /**
+   * Removes terms like "#2" from type when they also exist in size.
+   * These tokens are pencil-size markers and should not be suggested as type.
+   */
+  private List<String> removeOverlappingSizeMarkers(List<String> typeTerms, List<String> sizeTerms) {
+    TreeSet<String> sizeMarkers = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    for (String size : sizeTerms) {
+      if (isHashNumberMarker(size)) {
+        sizeMarkers.add(size.trim());
+      }
+    }
+
+    List<String> filtered = new ArrayList<>();
+    for (String type : typeTerms) {
+      if (!(isHashNumberMarker(type) && sizeMarkers.contains(type.trim()))) {
+        filtered.add(type);
+      }
+    }
+    return filtered;
+  }
+
+  /** Matches tokens like #2, #2b, #10. */
+  private boolean isHashNumberMarker(String value) {
+    if (value == null) {
+      return false;
+    }
+    return value.trim().matches("(?i)^#[0-9]+[a-z]?$");
   }
 
   /**

--- a/server/src/main/java/umm3601/terms/TermsController.java
+++ b/server/src/main/java/umm3601/terms/TermsController.java
@@ -122,8 +122,12 @@ public class TermsController {
       // batteries -> battery
       return word.substring(0, word.length() - 3) + "y";
     } else if (lower.endsWith("es") && lower.length() > 2) {
-      // boxes -> box, matches -> match
-      return word.substring(0, word.length() - 2);
+      if (word.contains("Headphones") || word.contains("Shoes")) {
+        return word;
+      } else {
+        // boxes -> box, matches -> match
+        return word.substring(0, word.length() - 2);
+      }
     } else if (lower.endsWith("s") && lower.length() > 1 && !lower.endsWith("ss")) {
       // pens -> pen, but not 'glass' -> 'glas'
       return word.substring(0, word.length() - 1);

--- a/server/src/test/java/umm3601/terms/TermsControllerSpec.java
+++ b/server/src/test/java/umm3601/terms/TermsControllerSpec.java
@@ -139,6 +139,30 @@ class TermsControllerSpec {
   }
 
   @Test
+  void getTermsFiltersOverlappingHashNumberMarkersFromType() {
+    DistinctIterable<String> empty = makeIterable(new ArrayList<>());
+    DistinctIterable<String> sizeFromInventory = makeIterable(Arrays.asList("#2"));
+    DistinctIterable<String> typeFromInventory = makeIterable(Arrays.asList("#2", "Sharpened"));
+
+    when(supplyListCollection.distinct(any(String.class), eq(String.class))).thenReturn(empty);
+    when(inventoryCollection.distinct(any(String.class), eq(String.class))).thenReturn(empty);
+
+    when(inventoryCollection.distinct(eq("size"), eq(String.class))).thenReturn(sizeFromInventory);
+    when(inventoryCollection.distinct(eq("type"), eq(String.class))).thenReturn(typeFromInventory);
+
+    doAnswer(inv -> {
+      Terms terms = inv.getArgument(0);
+      assertEquals(List.of("#2"), terms.size);
+      assertEquals(List.of("Sharpened"), terms.type);
+      return null;
+    }).when(ctx).json(any(Terms.class));
+
+    controller.getTerms(ctx);
+    verify(ctx).json(any(Terms.class));
+    verify(ctx).status(eq(HttpStatus.OK));
+  }
+
+  @Test
   void singularizeHandlesBasicCases() {
     assertEquals("box", controller.singularize("boxes"));
     assertEquals("battery", controller.singularize("batteries"));


### PR DESCRIPTION
Here I have updated the terms controller to work more efficiently. The auto fill part only includes terms within the supply list and inventory. Supply list seed data partly fixed for terms. Updated terms logic for the current supply list data.